### PR TITLE
Remove Google sign-in and initialize dashboard on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>App</title>
+  <!-- Google sign-in script removed -->
+  <!-- <script src="https://accounts.google.com/gsi/client" async defer></script> -->
+</head>
+<body>
+  <!-- <div id="login-screen">
+       <p>Login content</p>
+     </div> -->
+  <div id="dashboard" style="display:none;">
+    <h1>Dashboard</h1>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginScreen = document.getElementById('login-screen');
+  const dashboard = document.getElementById('dashboard');
+
+  if (loginScreen) {
+    loginScreen.style.display = 'none';
+  }
+  if (dashboard) {
+    dashboard.style.display = 'block';
+  }
+});


### PR DESCRIPTION
## Summary
- Comment out Google sign-in script and login screen in `index.html`
- Add DOMContentLoaded handler in `script.js` to hide login screen and show dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c00d0d2b483339b057ca1b204050c